### PR TITLE
getCoeff function. From python, pass number of taps: returns numpy array

### DIFF
--- a/Fir1.cpp
+++ b/Fir1.cpp
@@ -97,3 +97,12 @@ void Fir1::zeroCoeff() {
 	memset(coefficients, 0, sizeof(double)*taps);
 	offset = 0;
 }
+
+void Fir1::getCoeff(double* coeff_data, unsigned number_of_taps) {
+	if (number_of_taps != taps)
+		throw "Fir1: target of getCoefficients: size mismatch";
+ 
+	memcpy(coeff_data, coefficients, number_of_taps * sizeof(double));
+	/** \TODO in principal, if the target array is bigger, we could zero-pad it */
+}
+

--- a/Fir1.h
+++ b/Fir1.h
@@ -160,6 +160,16 @@ public:
 	void zeroCoeff();
 
 	/**
+	 * Copies the current filter coefficients into a provided array.
+	 * Useful after an adaptive filter has been trained to query
+	 * the result of its training.
+	 * \param coeff_data target where coefficients are copied
+	 * \param number_of_taps number of doubles to be copied
+	 * \throws char* number_of_taps isn't the same as the actual number of taps.
+	 */
+	void getCoeff(double* coeff_data, unsigned number_of_taps);
+
+	/**
          * Returns the number of taps.
          **/
 	unsigned getTaps() {return taps;};

--- a/fir1.i
+++ b/fir1.i
@@ -11,5 +11,6 @@
 %}
 
 %apply (double* IN_ARRAY1, int DIM1) {(double *coefficients, unsigned number_of_taps)};
+%apply (double* ARGOUT_ARRAY1, int DIM1) {(double *coeff_data, unsigned number_of_taps)};
 
 %include "Fir1.h"


### PR DESCRIPTION
Notes:

1. The C++ function throws an exception if the number of coefficients requested doesn't equal the number of coefficients in the curren object. This isn't handled gracefully in the Python interface yet.
2. In principal, it should only really throw if the target array is smaller than the number of coeffcients of the current object, and zero-pad.
3. No additional unit tests yet.
4. The python interface uses ARGOUT_ARRAY1 which might be considered a bit counterintuitive. You tell the method how many coefficients you want and it returns an array of them. so `coeffs = fir.getCoeff(10)` or something like that.
