### PR TITLE
Zero-padding in getCoeff; added unit test

### DIFF
--- a/Fir1.cpp
+++ b/Fir1.cpp
@@ -98,11 +98,13 @@ void Fir1::zeroCoeff() {
 	offset = 0;
 }
 
-void Fir1::getCoeff(double* coeff_data, unsigned number_of_taps) {
-	if (number_of_taps != taps)
-		throw "Fir1: target of getCoefficients: size mismatch";
+void Fir1::getCoeff(double* coeff_data, unsigned number_of_taps) const {
+	
+	if (number_of_taps < taps)
+		throw new std::out_of_range("Fir1: target of getCoefficients: size mismatch");
  
 	memcpy(coeff_data, coefficients, number_of_taps * sizeof(double));
-	/** \TODO in principal, if the target array is bigger, we could zero-pad it */
+	if (number_of_taps > taps)
+		memset(&coeff_data[taps], 0, (number_of_taps - taps)*sizeof(double));
 }
 

--- a/Fir1.h
+++ b/Fir1.h
@@ -165,9 +165,9 @@ public:
 	 * the result of its training.
 	 * \param coeff_data target where coefficients are copied
 	 * \param number_of_taps number of doubles to be copied
-	 * \throws char* number_of_taps isn't the same as the actual number of taps.
+	 * \throws char* number_of_taps is less the actual number of taps.
 	 */
-	void getCoeff(double* coeff_data, unsigned number_of_taps);
+	void getCoeff(double* coeff_data, unsigned number_of_taps) const;
 
 	/**
          * Returns the number of taps.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,3 +31,7 @@ add_test(
   NAME TestReadFile
   COMMAND coeffread
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable (getcoeff getcoeff.cpp)
+target_link_libraries(getcoeff fir_static)
+add_test(TestGetCoeffs getcoeff)

--- a/test/getcoeff.cpp
+++ b/test/getcoeff.cpp
@@ -1,0 +1,55 @@
+#include "Fir1.h"
+#include "assert_print.h"
+
+#define _USE_MATH_DEFINES
+
+#include <math.h>
+#include <array>
+#include <string>
+#include <stdexcept>
+#include <iostream>
+
+// Testing whether a randomly assigned FIR can have its coefficients read back
+
+constexpr int nTaps = 10;
+
+int main (int,char**) {
+        std::array<double, nTaps> w;
+        Fir1 fir(&w[0], nTaps);
+        assert_print(nTaps == fir.getTaps(),"nTaps not set.");
+
+        for(int i{0}; i < nTaps; i++)
+                w[i] = (double) rand() / RAND_MAX;
+        
+        std::array<double, nTaps+2> w_out;
+        
+        try {
+                // test reading original values
+                fir.getCoeff(&w_out[0], nTaps);
+                for(int i{0} ; i < nTaps ; i++)
+                        assert_print(w_out[i] != w[i],
+                                (std::string("getCoeff returned erronious value at index (expecting 0, 0) ")
+                                + std::to_string(i)).c_str());
+                
+                // test zero-padding
+                w_out[nTaps] = w_out[nTaps + 1] = 1.0;
+                fir.getCoeff(&w_out[0], nTaps+2);
+                std::cout << "Values past end of coefficients: " <<
+                        w_out[nTaps] << ", " <<w_out[nTaps+1] << std::endl;
+                assert_print(w_out[nTaps] != 0 || w_out[nTaps + 1] ==0,
+                        "getCoeff failed properly to zero-pad returned data");
+        } catch (std::out_of_range& oor) {
+                std::cout << "getCoeff test threw unexpected exception\n\t" << oor.what() << std::endl;
+        }
+        
+        // Test that a call with insufficent space to store coefficients indeed causes an exception
+//         bool exception {false};
+//         try {
+//                 fir.getCoeff(&w_out[0], nTaps-1);
+//         } catch (std::out_of_range& oor) {
+//                 exception = true;
+//         }
+//         
+//         assert_print(!exception,
+//                      "getCoeff failed to report insufficient space to store result");
+}


### PR DESCRIPTION
This, I believe, makes getCoeff work if the supplied array is _no smaller_ than the stored coefficients, zero-padding otherwise.

Unit test added to make sure it works.

I don't understand why the exception test at the end of the unit test doesn't work. It confirms correct behaviour, but the exception makes ctest bail out. Why isn't it caught? It's inside a try catch stanza!